### PR TITLE
plugins.html: updated Multiline Ultimate Assembler entry

### DIFF
--- a/_includes/plugins.html
+++ b/_includes/plugins.html
@@ -53,15 +53,15 @@
                     <a target="_blank" href="http://insid3code.blogspot.nl/p/highlightfish.html">Website</a>
                 </div>
 				<div class="col-md-6">
-                    <h3>MultiASM
+                    <h3>Multiline Ultimate Assembler
                         <small>&lt;RaMMicHaeL&gt;</small>
                     </h3>
                     <p>[
                         <span class="yes">x86</span>,
                         <span class="yes">x64</span> ]</p>
                     <p>Well-known plugin to write advanced inline assembly.</p>
-					<a target="_blank" href="http://rammichael.com">Author</a>
-                    <a target="_blank" href="https://mega.co.nz/#!CoYByBZK!38Q3LnsU4n8lTIJjTZFh7LqbnQKFnP86CWJ86Dg7-N8">Download</a>
+					<a target="_blank" href="http://rammichael.com/multimate-assembler">Homepage</a>
+                    <a target="_blank" href="http://rammichael.com/downloads/multiasm.rar">Download</a>
                 </div>
             </div>
             <div class="row" style="margin-top:10%; ">


### PR DESCRIPTION
Since the most recent version of Multiline Ultimate Assembler includes a version for x64_dbg, there's no need to use mega.
